### PR TITLE
fix: Configure patches project on extensions projects absence

### DIFF
--- a/src/main/kotlin/app/revanced/patches/gradle/SettingsPlugin.kt
+++ b/src/main/kotlin/app/revanced/patches/gradle/SettingsPlugin.kt
@@ -73,10 +73,10 @@ abstract class SettingsPlugin @Inject constructor(
             val extensionsProject = try {
                 rootProject.project(extensionsProjectPath)
             } catch (e: UnknownProjectException) {
-                return@rootProject
+                null
             }
 
-            extensionsProject.subprojects { extensionProject ->
+            extensionsProject?.subprojects { extensionProject ->
                 if (
                     extensionProject.buildFile.exists() &&
                     !extensionProject.parent!!.plugins.hasPlugin(ExtensionPlugin::class.java)


### PR DESCRIPTION
as the title says, `patches` project will not apply `PatchesPlugin` when `extensions` project not exists.