### PR TITLE
fix: Add shadow plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ hs_err_pid*
 
 # Generated files
 .idea/**/contentModel.xml
+.idea/**/misc.xml
+.idea/**/vcs.xml
+.idea/**/kotlinc.xml
+.idea/**/.gitignore
 
 # Sensitive or high-churn files
 .idea/**/dataSources/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
 group = "app.revanced"
 
 repositories {
+    gradlePluginPortal()
     mavenCentral()
     google()
 }
@@ -21,6 +22,7 @@ dependencies {
     implementation(libs.guava)
     implementation(libs.kotlin)
     implementation(libs.kotlin.android)
+    implementation(libs.shadow)
 
     implementation(gradleApi())
     implementation(gradleKotlinDsl())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ binary-compatibility-validator = "0.15.1"
 #noinspection GradleDependency
 agp = "8.2.2" # 8.3.0 causes Java verifier error: https://github.com/ReVanced/revanced-patches/issues/2818
 guava = "33.2.1-jre"
+shadow = "8.1.1"
 
 [libraries]
 binary-compatibility-validator = { module = "org.jetbrains.kotlinx.binary-compatibility-validator:org.jetbrains.kotlinx.binary-compatibility-validator.gradle.plugin", version.ref = "binary-compatibility-validator" }
@@ -12,6 +13,7 @@ kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "
 kotlin-android = { module = "org.jetbrains.kotlin.android:org.jetbrains.kotlin.android.gradle.plugin", version.ref = "kotlin" }
 android-application = { module = "com.android.application:com.android.application.gradle.plugin", version.ref = "agp" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
+shadow = { group = "com.github.johnrengelman", name = "shadow", version.ref = "shadow" }
 
 [plugins]
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin"}

--- a/src/main/kotlin/app/revanced/patches/gradle/PatchesPlugin.kt
+++ b/src/main/kotlin/app/revanced/patches/gradle/PatchesPlugin.kt
@@ -241,6 +241,10 @@ private fun Project.configureJarTask(patchesExtension: PatchesExtension) {
     tasks.withType(Jar::class.java).configureEach {
         it.archiveExtension.set("rvp")
 
+        if (it.archiveClassifier.orNull.isNullOrEmpty()) {
+            it.archiveClassifier.set("thin");
+        }
+
         it.manifest.apply {
             attributes["Name"] = patchesExtension.about.name
             attributes["Description"] = patchesExtension.about.description

--- a/src/main/kotlin/app/revanced/patches/gradle/PatchesPlugin.kt
+++ b/src/main/kotlin/app/revanced/patches/gradle/PatchesPlugin.kt
@@ -127,7 +127,7 @@ abstract class PatchesPlugin : Plugin<Project> {
 
             task.dependsOn(tasks["shadowJar"])
 
-            // As we don't depend on the JarTask anymore, we have to add these manually (no one needs a thin jar)
+            // Add these manually, as the task does not depend on the "jar" task (no one needs a thin jar).
             task.dependsOn(tasks.named("javadocJar"))
             task.dependsOn(tasks.named("sourcesJar"))
 

--- a/src/main/kotlin/app/revanced/patches/gradle/PatchesPlugin.kt
+++ b/src/main/kotlin/app/revanced/patches/gradle/PatchesPlugin.kt
@@ -248,8 +248,6 @@ private fun Project.configureJarTask(patchesExtension: PatchesExtension) {
         if (it.archiveClassifier.orNull.isNullOrEmpty()) {
             it.archiveClassifier.set("thin")
         }
-
-        // ShadowJar inherits the manifest from the JarTask, so changing it here will also change the fat jar
         it.manifest.apply {
             attributes["Name"] = patchesExtension.about.name
             attributes["Description"] = patchesExtension.about.description

--- a/src/main/kotlin/app/revanced/patches/gradle/PatchesPlugin.kt
+++ b/src/main/kotlin/app/revanced/patches/gradle/PatchesPlugin.kt
@@ -245,7 +245,7 @@ private fun Project.configureJarTask(patchesExtension: PatchesExtension) {
         it.archiveExtension.set("rvp")
 
         // JarTask includes the javadoc and sourcesjar. Be sure to only add the "-thin" filename suffix, if there isn't already one set
-        if (it.archiveClassifier.orNull == null) {
+        if (it.archiveClassifier.orNull.isNullOrEmpty()) {
             it.archiveClassifier.set("thin")
         }
 

--- a/src/main/kotlin/app/revanced/patches/gradle/PatchesPlugin.kt
+++ b/src/main/kotlin/app/revanced/patches/gradle/PatchesPlugin.kt
@@ -268,7 +268,7 @@ private fun Project.configureJarTask(patchesExtension: PatchesExtension) {
 
         it.minimize()
         it.isEnableRelocation = true
-        it.relocationPrefix = "app.revanced.libs"
+        it.relocationPrefix = "app.revanced.patches"
     }
     tasks.named("assemble") {
         it.dependsOn(tasks.named("shadowJar"))


### PR DESCRIPTION
This adds support for shading dependencies into the patches rvp file.

Needed for a fixup in https://github.com/ReVanced/revanced-patches/pull/5158

I also added some entries to the .gitignore file, which IntelliJ created automatically.